### PR TITLE
Add usage with webpack and less-loader to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ less.render(lessString, { plugins: [require('less-plugin-glob')] })
 ```
 
 If you are using Gulp or Grunt or something else, you can import and add plugin by same way as well.
+
+### Usage with webpack and less-loader
+
+When using webpack and `less-loader` >= 4.0, it's important to make sure that `less-loader` is configured *not* to use its webpack resolver, which is now [active by default](https://github.com/webpack-contrib/less-loader#imports). Otherwise, `less-plugin-glob` won't run at all because `less-loader` applies a LESS plugin that passes all queries to the webpack resolver (bypassing this plugin). To make `less-loader` revert to the LESS resolver, [specify the `paths` loader option](https://github.com/webpack-contrib/less-loader#less-resolver):
+
+    {
+      loader: "less-loader",
+      options: {
+        plugins: [lessPluginGlob],
+        paths: [path.resolve(__dirname, "path/to/my/styles")] // This is the important part!
+      }
+    }


### PR DESCRIPTION
This clarifies a gotcha when using `less-plugin-glob` with`webpack ` and `less-loader` >= 4.0, which is likely to be an issue for many.